### PR TITLE
Fix 'rename' prompt with prepopulated value

### DIFF
--- a/cfrs.el
+++ b/cfrs.el
@@ -55,7 +55,7 @@ Only the `:background' part is used."
   "Read a string using a pos-frame with given PROMPT and INITIAL-INPUT."
   (if (not (or (display-graphic-p)
                (not (fboundp #'display-buffer-in-side-window))))
-      (read-string prompt nil nil initial-input)
+      (read-string prompt initial-input)
     (let* ((buffer (get-buffer-create " *Pos-Frame-Read*"))
            (border-color (face-attribute 'cfrs-border-color :background nil t))
            (cursor (cfrs--determine-cursor-type))


### PR DESCRIPTION
Hello, had a day off today so I thought I'd tackle something that has been annoying me for a while now.

The second argument for `read-string` is `INITIAL-INPUT` which is used
to pre-populate the minibuffer, the fourth `DEFAULT-VALUE` is what it
returns in case the prompt has an empty string.

While the docs for `read-string` say `INITIAL-INPUT` has been superseded
by `DEFAULT-VALUE`, this is misleading as `DEFAULT-VALUE` by itself does
not pre-populate the minibuffer.

Example code:

```elisp
;; No pre-completed value, returns "" when empty.
(read-string "PROMPT ")

;; Pre-completed with "A", returns "" when empty.
(read-string "PROMPT " "A")

;; Pre-completed with "A", returns "B" when empty.
(read-string "PROMPT " "A" nil "B")

;; No pre-completed value, returns "B" when empty.
(read-string "PROMPT " nil nil "B")
```

Similar changes need to be done in treemacs (and all packages that use `read-string` (I can do that if this PR is accepted). I'll also write in he emacs mailing list about the weird `read-string` docs:

https://debbugs.gnu.org/cgi/bugreport.cgi?bug=50811